### PR TITLE
Send iOS symbolication files to Sentry

### DIFF
--- a/actions/sentry/upload-debug-files.ts
+++ b/actions/sentry/upload-debug-files.ts
@@ -4,7 +4,7 @@ import logger from "../../util/log.ts"
 export type SentryUploadIOSDebugFilesOptions = {
   authToken: string;
   projectId: string;
-  dsymPath: string;
+  dsymSearchPath: string;
 };
 
 export async function sentryUploadIOSDebugFiles(options: SentryUploadIOSDebugFilesOptions) {
@@ -20,7 +20,7 @@ export async function sentryUploadIOSDebugFiles(options: SentryUploadIOSDebugFil
         "divvun",
         "--project",
         options.projectId,
-        options.dsymPath,
+        options.dsymSearchPath,
       ]
     );
   } catch (error) {

--- a/pipelines/keyboard/divvun-keyboard.ts
+++ b/pipelines/keyboard/divvun-keyboard.ts
@@ -46,7 +46,7 @@ export async function runDivvunKeyboard(kbdgenBundlePath: string) {
     await sentryUploadIOSDebugFiles({
       authToken: secrets.get("sentry/token"),
       projectId: projectId,
-      dsymPath: "output", // Providing directory instead of direct filepath will make Sentry find and upload necessary dSYM files in given directory
+      dsymSearchPath: "output",
     })
   })
 }


### PR DESCRIPTION
Adds a step to CI that uploads .dSYM files to Sentry to symbolicate crash reports.