### PR TITLE
Add drb-kicker CD pipeline

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -46,6 +46,12 @@ import {
   runKeyboardViewerLint,
 } from "./pipelines/keyboard-viewer.ts"
 import {
+  pipelineDrbKicker,
+  runDrbKickerBumpManifest,
+  runDrbKickerDeploy,
+  runDrbKickerLint,
+} from "./pipelines/drb-kicker.ts"
+import {
   pipelineDict,
   runDictBuild,
   runDictDeploy,
@@ -396,6 +402,18 @@ async function runPipeline(args: any) {
       await runKeyboardViewerBumpManifest()
       break
     }
+    case "drb-kicker-lint": {
+      await runDrbKickerLint()
+      break
+    }
+    case "drb-kicker-deploy": {
+      await runDrbKickerDeploy()
+      break
+    }
+    case "drb-kicker-bump-manifest": {
+      await runDrbKickerBumpManifest()
+      break
+    }
     case "libpahkat-android": {
       await runLibpahkatAndroid()
       break
@@ -658,6 +676,10 @@ async function runCi(_args: any) {
     }
     case "keyboard-viewer": {
       pipeline = pipelineKeyboardViewer()
+      break
+    }
+    case "drb-kicker": {
+      pipeline = pipelineDrbKicker()
       break
     }
     case "pahkat": {

--- a/pipelines/drb-kicker.ts
+++ b/pipelines/drb-kicker.ts
@@ -1,0 +1,92 @@
+import * as builder from "~/builder.ts"
+import { BuildkitePipeline, CommandStep } from "~/builder/pipeline.ts"
+import * as targetModule from "~/target.ts"
+import { bumpArgoHelmImageTag } from "~/util/k8s-config.ts"
+
+const IMAGE = "ghcr.io/divvun/drb-kicker"
+const APPLICATION_PATH = "apps/services/drb-kicker-app.yaml"
+
+function command(input: CommandStep): CommandStep {
+  return {
+    ...input,
+    plugins: [
+      ...(input.plugins ?? []),
+      `ssh://git@github.com/divvun/divvun-actions.git#${targetModule.gitHash}`,
+    ],
+  }
+}
+
+export function pipelineDrbKicker(): BuildkitePipeline {
+  return {
+    steps: [
+      command({
+        key: "lint",
+        label: "Lint",
+        command: "divvun-actions run drb-kicker-lint",
+        agents: { queue: "linux" },
+      }),
+      command({
+        key: "build-push",
+        label: "Build & Push",
+        command: "divvun-actions run drb-kicker-deploy",
+        agents: { queue: "linux" },
+        branches: "main",
+        depends_on: "lint",
+      }),
+      command({
+        label: "Bump k8s app manifest",
+        command: "divvun-actions run drb-kicker-bump-manifest",
+        agents: { queue: "linux" },
+        branches: "main",
+        depends_on: "build-push",
+      }),
+    ],
+  }
+}
+
+export async function runDrbKickerLint() {
+  await builder.exec("cargo", ["fmt", "--check"])
+  await builder.exec("cargo", [
+    "clippy",
+    "--all-targets",
+    "--",
+    "-D",
+    "warnings",
+  ])
+}
+
+export async function runDrbKickerDeploy() {
+  const tag = `sha-${builder.env.commit}`
+
+  await builder.exec("docker", [
+    "build",
+    "-t",
+    `${IMAGE}:latest`,
+    "-t",
+    `${IMAGE}:${tag}`,
+    ".",
+  ])
+
+  await builder.group("Pushing image", async () => {
+    await Promise.all([
+      builder.exec("docker", ["push", `${IMAGE}:latest`]),
+      builder.exec("docker", ["push", `${IMAGE}:${tag}`]),
+    ])
+  })
+
+  await builder.setMetadata("drb-kicker-tag", tag)
+}
+
+export async function runDrbKickerBumpManifest() {
+  const tag = (await builder.metadata("drb-kicker-tag")).trim()
+  if (tag.length === 0) {
+    throw new Error("Buildkite metadata drb-kicker-tag was empty")
+  }
+
+  await bumpArgoHelmImageTag({
+    imageName: IMAGE,
+    tag,
+    applicationPath: APPLICATION_PATH,
+    commitMessage: `Update drb-kicker image to ${tag}`,
+  })
+}


### PR DESCRIPTION
## Summary

Gives drb-kicker the same GitOps CD path the org already uses for `keyboard-viewer`, so a merge to drb-kicker's `main` results in a deployed image instead of today's manual `just deploy` + `kubectl rollout restart`.

drb-kicker is an Argo CD **Helm** app (`apps/services/drb-kicker-app.yaml`, namespace `pahkat`), so it follows `keyboard-viewer` exactly rather than the Kustomize (`borealium`) variant.

## Pipeline (`pipelines/drb-kicker.ts`)

1. **Lint** — `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings`.
2. **Build & Push** (`main` only) — `docker build` the repo's existing multi-stage Dockerfile, tag `:latest` and `:sha-<commit>`, push both, stash the sha tag in Buildkite metadata.
3. **Bump k8s app manifest** (`main` only) — `bumpArgoHelmImageTag` rewrites `image.tag` in `apps/services/drb-kicker-app.yaml`; Argo CD's automated sync + selfHeal then rolls the Deployment.

Wired into `cli.ts` (`runCi` dispatch + `run` subcommands) under repo name `drb-kicker`.

## Why this fixes the current gap

The Argo app currently pins `image.tag: latest`. Pushing a new `:latest` produces **no manifest diff**, so Argo never re-syncs — deploys only happen if a human manually restarts the pod. Moving to `sha-<commit>` tags + an automated bump gives Argo a real diff to reconcile, making `merge → deployed` actually true.

## Out of band (cannot be done from this repo)

- A Buildkite pipeline for the `drb-kicker` repo must exist and run `divvun-actions` (same bootstrap as `keyboard-viewer`, which has no in-repo `.buildkite/`).
- The `linux` queue agent needs: Docker + ghcr push creds (`ghcr-secret` already in use), push access to `k8s-config` over SSH (already used by existing bump steps), and a stable Rust toolchain for the lint step (same assumption as the `divvun-worker-tts` Rust build).
- First successful run flips `apps/services/drb-kicker-app.yaml` from `latest` to `sha-<commit>` automatically; no manual `k8s-config` edit needed.