### PR TITLE
docker: stop installing openssh in the alpine agent image

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -12,7 +12,7 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/main" > /etc/apk/repositor
     echo "https://dl-cdn.alpinelinux.org/alpine/v3.23/community" >> /etc/apk/repositories
 
 # System packages (apk)
-RUN apk update && apk upgrade && apk add --no-cache \
+RUN echo "Get cache-busted, loser" && apk update && apk upgrade && apk add --no-cache \
     autoconf \
     automake \
     bash \
@@ -44,7 +44,6 @@ RUN apk update && apk upgrade && apk add --no-cache \
     llvm21-dev \
     make \
     ninja \
-    openssh \
     openssl-dev \
     patch \
     patchelf \
@@ -114,7 +113,6 @@ RUN mkdir -p /opt/sysroot-aarch64 && \
     llvm21-dev \
     make \
     ninja \
-    openssh \
     openssl-dev \
     patch \
     patchelf \

--- a/docker/images/alpine.ts
+++ b/docker/images/alpine.ts
@@ -46,7 +46,6 @@ const ALPINE_PACKAGES = [
   "llvm21-dev",
   "make",
   "ninja",
-  "openssh",
   "openssl-dev",
   "patch",
   "patchelf",

--- a/docker/lib/image.ts
+++ b/docker/lib/image.ts
@@ -114,7 +114,13 @@ export function renderImage(def: ImageDef): string {
   if (def.apkPackages && def.apkPackages.length > 0) {
     const pkgs = def.apkPackages.map((p) => `    ${p}`).join(" \\\n")
     out.push(`# System packages (apk)`)
-    out.push(`RUN apk update && apk upgrade && apk add --no-cache \\`)
+    // Change the echo string to invalidate the cached apk layer. Needed when a
+    // bad apk state (e.g. a mid-publish Alpine mirror index where a split
+    // package pair is briefly inconsistent) gets baked into the Docker layer
+    // cache and makes `apk add` fail deterministically on every rebuild.
+    out.push(
+      `RUN echo "Get cache-busted, loser" && apk update && apk upgrade && apk add --no-cache \\`,
+    )
     out.push(pkgs)
     out.push("")
   }

--- a/docker/lib/install.ts
+++ b/docker/lib/install.ts
@@ -119,7 +119,8 @@ export function aptInstall(packages: string[]): string {
 export function apkInstall(packages: string[]): string {
   const pkgLines = packages.map((p) => `    ${p}`).join(" \\\n")
   return [
-    `RUN apk update && apk upgrade && apk add --no-cache \\`,
+    // Change the echo string to force a poisoned apk layer to rebuild.
+    `RUN echo "Get cache-busted, loser" && apk update && apk upgrade && apk add --no-cache \\`,
     pkgLines,
   ].join("\n")
 }


### PR DESCRIPTION
## Problem

The agent-image build (`Dockerfile.alpine`) fails deterministically:

```
ERROR: unable to select packages:
  openssh-client-common-10.3_p1-r0:
    breaks: openssh-client-default-10.2_p1-r0[openssh-client-common=10.2_p1-r0]
```

Ruled out the usual suspects:
- **Not layer cache** — a cache-busted rebuild (the `echo "Get cache-busted, loser"` line) re-ran `apk update` fresh and still failed.
- **Not a transient mirror race** — the freshly-fetched index genuinely can't satisfy it.

Root cause: the base `buildkite/agent:alpine` image already has `openssh-client-default-10.2` installed, which **hard-pins `openssh-client-common=10.2`**. The current Alpine `v3.23` index only offers `openssh-client-common` at `10.3` (and no `openssh-client-default-10.3`), so the openssh family is unsatisfiable. Our explicit **`openssh`** in the package list (the full meta, including the *server*) is what pulls that broken family into the resolve.

## Fix

Drop `openssh` from the alpine package list. Every openssh use in this repo is **git-over-ssh client** (`ssh://git@github.com/...`, `git@github.com:...`); nothing runs an ssh server, and the base image already ships the client. So removing the meta loses nothing we use and stops `apk add` from touching the broken family.

Changed at the source (`docker/images/alpine.ts`) and regenerated via `deno task docker:gen`. Also kept an echo cache-bust token on the apk `RUN` line as a future knob (bump the string to force a layer rebuild).