### PR TITLE
Add divvun-worker-grammar CD pipeline

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -52,6 +52,11 @@ import {
   runDrbKickerLint,
 } from "./pipelines/drb-kicker.ts"
 import {
+  pipelineDivvunWorkerGrammar,
+  runDivvunWorkerGrammarBumpManifest,
+  runDivvunWorkerGrammarDeploy,
+} from "./pipelines/divvun-worker-grammar.ts"
+import {
   pipelineDict,
   runDictBuild,
   runDictDeploy,
@@ -414,6 +419,14 @@ async function runPipeline(args: any) {
       await runDrbKickerBumpManifest()
       break
     }
+    case "divvun-worker-grammar-deploy": {
+      await runDivvunWorkerGrammarDeploy()
+      break
+    }
+    case "divvun-worker-grammar-bump-manifest": {
+      await runDivvunWorkerGrammarBumpManifest()
+      break
+    }
     case "libpahkat-android": {
       await runLibpahkatAndroid()
       break
@@ -680,6 +693,10 @@ async function runCi(_args: any) {
     }
     case "drb-kicker": {
       pipeline = pipelineDrbKicker()
+      break
+    }
+    case "divvun-worker-grammar": {
+      pipeline = pipelineDivvunWorkerGrammar()
       break
     }
     case "pahkat": {

--- a/pipelines/divvun-worker-grammar.ts
+++ b/pipelines/divvun-worker-grammar.ts
@@ -1,0 +1,79 @@
+import * as builder from "~/builder.ts"
+import { BuildkitePipeline, CommandStep } from "~/builder/pipeline.ts"
+import * as targetModule from "~/target.ts"
+import { bumpChartImageTag } from "~/util/k8s-config.ts"
+
+const IMAGE = "ghcr.io/divvun/divvun-worker-grammar"
+// One worker binary serves every channel (channels differ only in data). All
+// grammar ApplicationSets defer to the chart default, so pinning the tag here —
+// a plain values.yaml — rolls every channel at once, replacing mutable `latest`.
+const CHART_VALUES_PATH = "charts/grammar-language/values.yaml"
+
+function command(input: CommandStep): CommandStep {
+  return {
+    ...input,
+    plugins: [
+      ...(input.plugins ?? []),
+      `ssh://git@github.com/divvun/divvun-actions.git#${targetModule.gitHash}`,
+    ],
+  }
+}
+
+export function pipelineDivvunWorkerGrammar(): BuildkitePipeline {
+  return {
+    steps: [
+      command({
+        key: "build-push",
+        label: "Build & Push",
+        command: "divvun-actions run divvun-worker-grammar-deploy",
+        agents: { queue: "linux" },
+        branches: "main",
+      }),
+      command({
+        label: "Bump k8s ApplicationSet",
+        command: "divvun-actions run divvun-worker-grammar-bump-manifest",
+        agents: { queue: "linux" },
+        branches: "main",
+        depends_on: "build-push",
+      }),
+    ],
+  }
+}
+
+export async function runDivvunWorkerGrammarDeploy() {
+  const tag = `sha-${builder.env.commit}`
+
+  // The repo's multi-stage Dockerfile builds the binary internally (./x build).
+  await builder.exec("docker", [
+    "build",
+    "-t",
+    `${IMAGE}:latest`,
+    "-t",
+    `${IMAGE}:${tag}`,
+    ".",
+  ])
+
+  await builder.group("Pushing image", async () => {
+    await Promise.all([
+      builder.exec("docker", ["push", `${IMAGE}:latest`]),
+      builder.exec("docker", ["push", `${IMAGE}:${tag}`]),
+    ])
+  })
+
+  await builder.setMetadata("divvun-worker-grammar-tag", tag)
+}
+
+export async function runDivvunWorkerGrammarBumpManifest() {
+  const tag = (await builder.metadata("divvun-worker-grammar-tag")).trim()
+  if (tag.length === 0) {
+    throw new Error("Buildkite metadata divvun-worker-grammar-tag was empty")
+  }
+
+  await bumpChartImageTag({
+    imageName: IMAGE,
+    tag,
+    valuesPath: CHART_VALUES_PATH,
+    imageKey: "workerImage",
+    commitMessage: `Update divvun-worker-grammar image to ${tag}`,
+  })
+}

--- a/util/k8s-config.ts
+++ b/util/k8s-config.ts
@@ -29,6 +29,19 @@ export type BumpArgoHelmImageTagOptions = {
   commitMessage: string
 }
 
+export type BumpChartImageTagOptions = {
+  /** Full image name without tag, e.g. "ghcr.io/divvun/divvun-worker-grammar". */
+  imageName: string
+  /** New tag (e.g. "sha-deadbeef"). */
+  tag: string
+  /** Path within the k8s-config repo to the chart's values.yaml. */
+  valuesPath: string
+  /** Top-level image key in the values, e.g. "workerImage" or "image". */
+  imageKey: string
+  /** Commit message for the bump. */
+  commitMessage: string
+}
+
 type UpdateK8sConfigFileOptions = {
   /** Path within the k8s-config repo to edit. */
   path: string
@@ -141,6 +154,35 @@ export async function bumpArgoHelmImageTag(
       image.set("tag", opts.tag)
       helm.set("values", String(valuesDoc))
 
+      return String(doc)
+    },
+  })
+}
+
+/**
+ * Bump an image tag in a chart's `values.yaml` — a plain data file, so this is
+ * a straight YAML edit (unlike an ApplicationSet, whose `helm.values` is a
+ * Go-templated string). Used to pin worker images: the ApplicationSets defer to
+ * the chart default, and CD patches the default here.
+ */
+export async function bumpChartImageTag(
+  opts: BumpChartImageTagOptions,
+): Promise<void> {
+  await updateK8sConfigFile({
+    path: opts.valuesPath,
+    commitMessage: opts.commitMessage,
+    update(source) {
+      const doc = YAML.parseDocument(source)
+      const image = doc.get(opts.imageKey) as YAML.YAMLMap | null
+      if (!image || !YAML.isMap(image)) {
+        throw new Error(`No ${opts.imageKey} map in ${opts.valuesPath}`)
+      }
+      if (image.get("repository") !== opts.imageName) {
+        throw new Error(
+          `Expected ${opts.imageKey}.repository ${opts.imageName} in ${opts.valuesPath}`,
+        )
+      }
+      image.set("tag", opts.tag)
       return String(doc)
     },
   })


### PR DESCRIPTION
Adds a CD pipeline for `divvun-worker-grammar`.

On push to `main`:
1. Build the repo's Dockerfile, tag `:latest` + `:sha-<commit>`, push both.
2. Bump `workerImage.tag` to the sha in `charts/grammar-language/values.yaml`.

The grammar ApplicationSets defer to the chart default, so one bump rolls all channels (a paired k8s-config change drops their redundant `workerImage` overrides).

New `bumpChartImageTag` does a plain YAML edit of a chart's `values.yaml` (unlike ApplicationSets, whose `helm.values` is Go-templated). Wired into `cli.ts` as `divvun-worker-grammar`.