### PR TITLE
Worker CD: single sha pin (drop channel model)

### DIFF
--- a/pipelines/worker-cd.ts
+++ b/pipelines/worker-cd.ts
@@ -3,46 +3,35 @@ import { BuildkitePipeline, CommandStep } from "~/builder/pipeline.ts"
 import * as targetModule from "~/target.ts"
 import { bumpChartImageTag } from "~/util/k8s-config.ts"
 
-/** CD for a divvun worker, following the channel model the language data packs
- * already use:
+/** CD for a divvun worker. On push to main: build the repo's Dockerfile, push
+ * `ghcr.io/divvun/<name>:sha-<commit>`, and pin that tag in the worker's chart
+ * values.yaml in k8s-config.
  *
- * - push to main   → build+push `:sha-<commit>` → bump the unstable pin
- * - push tag vX.Y.Z → build+push `:vX.Y.Z` (and `:sha-<commit>`) → bump the
- *   release pin, which serves prod AND beta (beta runs prod's code by design;
- *   only its data channel differs)
- *
- * The pins are plain values files inside the worker's chart in k8s-config
- * (`<chartPath>/channels/{release,unstable}.yaml`), referenced per channel by
- * the ApplicationSets via helm valueFiles. Nothing references a mutable tag:
- * `:latest` is not pushed at all. */
+ * There are no per-channel worker images: every language channel
+ * (unstable/beta/prod) runs the same worker binary and differs only in its data
+ * pack. So one pin, bumped on every merge to main. No release tags, no mutable
+ * `:latest`. */
 export type WorkerCd = {
   /** Repo/binary name, e.g. "divvun-worker-grammar". Doubles as the cli
    * command prefix (`<name>-deploy`, `<name>-bump-manifest`), the ghcr image
    * name, and the Buildkite metadata key. */
   name: string
-  /** Path within k8s-config to the worker's chart directory. */
-  chartPath: string
+  /** Path within k8s-config to the chart values.yaml that pins the image. */
+  chartValuesPath: string
 }
 
 export const DIVVUN_WORKER_GRAMMAR: WorkerCd = {
   name: "divvun-worker-grammar",
-  chartPath: "charts/grammar-language",
+  chartValuesPath: "charts/grammar-language/values.yaml",
 }
 
 export const DIVVUN_WORKER_SPELLER: WorkerCd = {
   name: "divvun-worker-speller",
-  chartPath: "charts/speller-language",
+  chartValuesPath: "charts/speller-language/values.yaml",
 }
-
-const RELEASE_TAG = /^v\d+\.\d+\.\d+$/
 
 function image(cd: WorkerCd): string {
   return `ghcr.io/divvun/${cd.name}`
-}
-
-function releaseTag(): string | undefined {
-  const tag = builder.env.tag
-  return tag && RELEASE_TAG.test(tag) ? tag : undefined
 }
 
 function command(input: CommandStep): CommandStep {
@@ -56,21 +45,6 @@ function command(input: CommandStep): CommandStep {
 }
 
 export function pipelineWorkerCd(cd: WorkerCd): BuildkitePipeline {
-  // A tag build that isn't a release tag has nothing to do.
-  if (builder.env.tag && !releaseTag()) {
-    return {
-      steps: [
-        {
-          label: `Tag ${builder.env.tag} is not a release tag (vX.Y.Z); nothing to do`,
-          command: "true",
-          agents: { queue: "linux" },
-        },
-      ],
-    }
-  }
-
-  // Release builds have env.tag set; main builds are filtered to main.
-  const branches = releaseTag() ? undefined : "main"
   return {
     steps: [
       command({
@@ -78,13 +52,13 @@ export function pipelineWorkerCd(cd: WorkerCd): BuildkitePipeline {
         label: "Build & Push",
         command: `divvun-actions run ${cd.name}-deploy`,
         agents: { queue: "linux" },
-        branches,
+        branches: "main",
       }),
       command({
         label: "Bump k8s chart",
         command: `divvun-actions run ${cd.name}-bump-manifest`,
         agents: { queue: "linux" },
-        branches,
+        branches: "main",
         depends_on: "build-push",
       }),
     ],
@@ -92,24 +66,20 @@ export function pipelineWorkerCd(cd: WorkerCd): BuildkitePipeline {
 }
 
 export async function runWorkerCdDeploy(cd: WorkerCd) {
-  const shaTag = `sha-${builder.env.commit}`
-  const release = releaseTag()
-  // Release builds also get the sha tag for traceability.
-  const tags = release ? [release, shaTag] : [shaTag]
+  const tag = `sha-${builder.env.commit}`
 
   await builder.exec("docker", [
     "build",
-    ...tags.flatMap((t) => ["-t", `${image(cd)}:${t}`]),
+    "-t",
+    `${image(cd)}:${tag}`,
     ".",
   ])
 
   await builder.group("Pushing image", async () => {
-    await Promise.all(
-      tags.map((t) => builder.exec("docker", ["push", `${image(cd)}:${t}`])),
-    )
+    await builder.exec("docker", ["push", `${image(cd)}:${tag}`])
   })
 
-  await builder.setMetadata(`${cd.name}-tag`, tags[0])
+  await builder.setMetadata(`${cd.name}-tag`, tag)
 }
 
 export async function runWorkerCdBumpManifest(cd: WorkerCd) {
@@ -118,14 +88,11 @@ export async function runWorkerCdBumpManifest(cd: WorkerCd) {
     throw new Error(`Buildkite metadata ${cd.name}-tag was empty`)
   }
 
-  const channel = releaseTag() ? "release" : "unstable"
   await bumpChartImageTag({
     imageName: image(cd),
     tag,
-    valuesPath: `${cd.chartPath}/channels/${channel}.yaml`,
+    valuesPath: cd.chartValuesPath,
     imageKey: "workerImage",
-    commitMessage: channel === "release"
-      ? `Release ${cd.name} ${tag} (prod+beta)`
-      : `Update ${cd.name} unstable image to ${tag}`,
+    commitMessage: `Update ${cd.name} image to ${tag}`,
   })
 }


### PR DESCRIPTION
Corrects #20's model. Worker binaries have no channels — every language channel (unstable/beta/prod) runs the same worker image, differing only in data pack. So worker CD collapses to:

- push to main → build `ghcr.io/divvun/<worker>:sha-<commit>` → bump the one `charts/<worker>/values.yaml` `workerImage.tag`.

No release-tag detection, no `channels/{release,unstable}.yaml`, no `:latest`. Grammar and speller still share `worker-cd.ts`; cli command names unchanged.

Pairs with a k8s-config revert of #6 (removing the per-channel pin files). Merge k8s-config first.